### PR TITLE
ConvertArguments: support json.Number and reject float64

### DIFF
--- a/web3_test.go
+++ b/web3_test.go
@@ -1,6 +1,7 @@
 package web3
 
 import (
+	"encoding/json"
 	"math/big"
 	"reflect"
 	"testing"
@@ -23,24 +24,21 @@ func Test_parseParam(t *testing.T) {
 	}{
 		{"int256<-int", abi.IntTy, 256, 1, big.NewInt(1), false},
 		{"int256<-big.Int", abi.IntTy, 256, big.NewInt(1), big.NewInt(1), false},
-		{"int256<-float64", abi.IntTy, 256, float64(1), big.NewInt(1), false},
 
 		{"uint256<-int", abi.UintTy, 256, 1, big.NewInt(1), false},
 		{"uint256<-big.Int", abi.UintTy, 256, big.NewInt(1), big.NewInt(1), false},
-		{"uint256<-float64", abi.UintTy, 256, float64(1), big.NewInt(1), false},
 
 		{"int8<-int", abi.IntTy, 8, 1, int8(1), false},
 		{"int8<-big.Int", abi.IntTy, 8, big.NewInt(1), int8(1), false},
-		{"int8<-float64", abi.IntTy, 8, float64(1), int8(1), false},
 
 		{"uint8<-int", abi.UintTy, 8, 1, uint8(1), false},
 		{"uint8<-big.Int", abi.UintTy, 8, big.NewInt(1), uint8(1), false},
-		{"uint8<-float64", abi.UintTy, 8, float64(1), uint8(1), false},
 
 		{"int256<-hex", abi.IntTy, 256, "0x1", big.NewInt(1), false},
 		{"int256<-string", abi.IntTy, 256, "1", big.NewInt(1), false},
 
 		{"uint256<-zero", abi.UintTy, 256, "0", big.NewInt(0), false},
+		{"uint256<-json", abi.UintTy, 64, json.Number("10000000000000001"), uint64(10000000000000001), false},
 
 		{"address<-address", abi.AddressTy, 0, common.HexToAddress(addr), common.HexToAddress(addr), false},
 		{"address<-hex", abi.AddressTy, 0, addr, common.HexToAddress(addr), false},
@@ -54,6 +52,7 @@ func Test_parseParam(t *testing.T) {
 		// Error cases:
 		{"uint256<-negative", abi.UintTy, 256, -1, nil, true},
 		{"uint8<-negative", abi.UintTy, 8, -1, nil, true},
+		{"int256<-float64", abi.IntTy, 256, float64(1), nil, true},
 		{"uint8<-float", abi.UintTy, 8, 1.1, nil, true},
 		{"uint8<-negative-float", abi.UintTy, 8, -1.1, nil, true},
 	}


### PR DESCRIPTION
This PR proposes adding `ConvertArguments()` support for `json.Number` and possibly removing support for `float64`, for the follow reasons:

`ExampleConvertArgumentsFromJSONLossy` demonstrates two cases where using the `encoding/json` default of `float64` for numbers is not accurate. Rounding can occur during JSON deserialization which is not caught by the exactness check in `ConvertArguments()` (and in fact, it _cannot be detected_ - the information is lost beforehand).
```go
func ExampleConvertArgumentsFromJSONLossy() {
	args := abi.Arguments{abiUint(64), abiUint(64)}
	jsonStr := `[10000000000000000.1, 10000000000000001]`
	// Expectation: The first parameter should be rejected as 'not exact',
	// and the second should pass through with full precision.

	fmt.Println("JSON:", jsonStr)

	var params []interface{}
	err := json.Unmarshal([]byte(jsonStr), &params)
	if err != nil {
		fmt.Println("Failed to unmarshal JSON:", err)
		return
	}
	// Silent Failure: At this point, information is already lost; both float64
	// variables hold 'exact' integers not equal to the originals.
	fmt.Println("Decoded:", params)

	converted, err := ConvertArguments(args, params)
	if err != nil {
		fmt.Println("Failed to convert arguments:", err)
	}
	// Consequences: When converting to big.Int through big.Float,
	// both float64 parameters pass the 'exactness test' as integers.
	fmt.Println("Converted:", converted)

	// Output:
	// JSON: [10000000000000000.1, 10000000000000001]
	// Decoded: [1e+16 1e+16]
	// Converted: [10000000000000000 10000000000000000]
}
```

1) `10000000000000000.1`->`10000000000000000`: In the first case, some precision is lost, but it _could_ be considered acceptable behavior since the original value could not be represented in the final integer type anyways, and was rounded appropriately. However, rejecting all non-integers would be a reasonable policy as well (and our exactness check suggests that this was the original intent).
2) `10000000000000001`->`10000000000000000`: On the other hand, the second case is clearly a problem. The original value is an integer which _can_ be represented exactly in the final type, but which is silently rounded along the way. Depending on the semantics of the value, this may not only
be 'slight rounding' - for example, if this were an ID or an index, then any level of inaccuracy could be equally wrong and fail or otherwise fundamentally change a contract call.

## How do we fix this?
1) Support json.Number for full precision, and recommend `json.Decoder.UseNumber()` in the docs
2) Reject floats, and include a note about `UseNumber()`

This first draft of this PR implements both #1 and #2. If we don't want to lose a previously supported feature, then we could back off on #2 and change the comment to a 'caller beware'-type warning.

## Open Questions
1) If we reject `float64`, should the minor version be bumped?
2) Should we generalize from just supporting `json.Number` to _any_ string type? (e.g. `reflect.Type.{AssignableTo|ConvertibleTo}`)

