### PR TITLE
GitHub Actions CI issues #130

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       # good functions and things here: https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions#functions
       run: |
         echo "exiting, skip ci found"
-        exit 1
+        exit 78
 
     - name: Set up Go
       uses: actions/setup-go@v1


### PR DESCRIPTION
Github Actions will mark a check as "neutral" (neither failed/succeeded) when you exit with code 78. This will however cancel any other actions running in parallel in this workflow.