### PR TITLE
Lock in openzeppelin version on generated files (and a bit of clean up)

### DIFF
--- a/assets/erc20.go
+++ b/assets/erc20.go
@@ -2,6 +2,7 @@ package assets
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"strconv"
 	"strings"
@@ -17,8 +18,9 @@ type Erc20Params struct {
 	Burnable  bool
 }
 
-func GenERC20(ctx context.Context, params *Erc20Params) (string, error) {
+func GenERC20(ctx context.Context, openZeppelinVersion string, params *Erc20Params) (string, error) {
 	var part1, part2, part3 strings.Builder
+	part1.WriteString(fmt.Sprintf("// @openzeppelin v%v\n", openZeppelinVersion))
 	part1.WriteString("pragma solidity ^0.5.11;\n\nimport \"./lib/oz/contracts/token/ERC20/ERC20Detailed.sol\";\n")
 	part2.WriteString("\ncontract ")
 	part2.WriteString(params.Symbol)

--- a/cmd/web3/main.go
+++ b/cmd/web3/main.go
@@ -1281,7 +1281,7 @@ func BuildSol(ctx context.Context, filename, compiler string) {
 	if filename == "" {
 		fatalExit(errors.New("Missing file name arg"))
 	}
-	flattenedFile, err := FlattenSourceFile(filename, "")
+	flattenedFile, err := FlattenSourceFile(ctx, filename, "")
 	if err != nil {
 		fatalExit(fmt.Errorf("Cannot generate the flattened file: %v", err))
 	}
@@ -1345,7 +1345,7 @@ func FlattenSol(ctx context.Context, iFile, oFile string) {
 	if iFile == "" {
 		fatalExit(errors.New("Missing file name arg"))
 	}
-	oFile, err := FlattenSourceFile(iFile, oFile)
+	oFile, err := FlattenSourceFile(ctx, iFile, oFile)
 	if err != nil {
 		fatalExit(fmt.Errorf("Cannot generate the flattened file: %v", err))
 	}


### PR DESCRIPTION
It adds a line at the top like:

```
// @openzeppelin v2.5.0
```

Then when it's being built and the openzeppelin libs aren't there, it will pull the right version. 

We were pulling master which is already working towards next version of solidity, 0.6.X, and it doesn't have ERC20Mintable anymore so it was breaking. This should fix issues like that. 
