### PR TITLE
Skip verify after deploy if no contract source

### DIFF
--- a/cmd/web3/main.go
+++ b/cmd/web3/main.go
@@ -1400,7 +1400,9 @@ func DeploySol(ctx context.Context, network web3.Network, privateKey, contractNa
 	if !upgradeable {
 		fmt.Println("Contract has been successfully deployed with transaction:", tx.Hash.Hex())
 		fmt.Println("Contract address is:", receipt.ContractAddress.Hex())
-		VerifyContract(ctx, network, explorerURL, receipt.ContractAddress.Hex(), strings.TrimSuffix(contractName, ".bin"), contractSource, compilerVersion)
+		if contractSource != "" {
+			VerifyContract(ctx, network, explorerURL, receipt.ContractAddress.Hex(), strings.TrimSuffix(contractName, ".bin"), contractSource, compilerVersion)
+		}
 		return
 	}
 


### PR DESCRIPTION
This allows us to skip contract verification after deploy if we didn't supply contract source code.