### PR TITLE
add gas-limit flag to deploy

### DIFF
--- a/cmd/web3/did.go
+++ b/cmd/web3/did.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gochain/gochain/v3/core/types"
+
 	"github.com/gochain/gochain/v3/accounts/abi"
 	"github.com/gochain/gochain/v3/common"
 	"github.com/gochain/gochain/v3/crypto"
@@ -103,6 +105,11 @@ func CreateDID(ctx context.Context, rpcURL, privateKey, id, registryAddress stri
 	if err != nil {
 		log.Fatalf("Cannot get the receipt: %v", err)
 	}
+
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		fatalExit(fmt.Errorf("DID contract call failed: %s", tx.Hash.Hex()))
+	}
+
 	fmt.Println("Successfully registered DID:", d.String())
 	fmt.Println("DID Document IPFS Hash:", hash)
 	fmt.Println("Transaction address:", receipt.TxHash.Hex())

--- a/web3.go
+++ b/web3.go
@@ -158,7 +158,7 @@ func CallTransactFunction(ctx context.Context, client Client, myabi abi.ABI, add
 
 // DeployContract submits a contract creation transaction.
 // abiJSON is only required when including params for the constructor.
-func DeployContract(ctx context.Context, client Client, privateKeyHex string, binHex, abiJSON string, params ...interface{}) (*Transaction, error) {
+func DeployContract(ctx context.Context, client Client, privateKeyHex string, binHex, abiJSON string, gasLimit uint64, params ...interface{}) (*Transaction, error) {
 	if len(privateKeyHex) > 2 && privateKeyHex[:2] == "0x" {
 		privateKeyHex = privateKeyHex[2:]
 	}
@@ -203,7 +203,7 @@ func DeployContract(ctx context.Context, client Client, privateKeyHex string, bi
 		binData = append(binData, input...)
 	}
 	//TODO try to use web3.Transaction only; can't sign currently
-	tx := types.NewContractCreation(nonce, big.NewInt(0), 2000000, gasPrice, binData)
+	tx := types.NewContractCreation(nonce, big.NewInt(0), gasLimit, gasPrice, binData)
 	signedTx, err := types.SignTx(tx, types.HomesteadSigner{}, privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("cannot sign transaction: %v", err)


### PR DESCRIPTION
This PR enables setting a `-gas-limit` to override the default of 2,000,000, which was causing https://github.com/gochain/gochain/issues/413
It also adds some tx receipt status checks.