### PR TITLE
leave out an empty From address on eth_call

### DIFF
--- a/client.go
+++ b/client.go
@@ -256,8 +256,10 @@ func toBlockNumArg(number *big.Int) string {
 
 func toCallArg(msg CallMsg) interface{} {
 	arg := map[string]interface{}{
-		"from": msg.From,
 		"to":   msg.To,
+	}
+	if msg.From != nil {
+		arg["from"] = msg.From
 	}
 	if len(msg.Data) > 0 {
 		arg["data"] = hexutil.Bytes(msg.Data)

--- a/types.go
+++ b/types.go
@@ -10,7 +10,7 @@ import (
 )
 
 type CallMsg struct {
-	From     common.Address  // the sender of the 'transaction'
+	From     *common.Address  // the sender of the 'transaction'
 	To       *common.Address // the destination contract (nil for contract creation)
 	Gas      uint64          // if 0, the call executes with near-infinite gas
 	GasPrice *big.Int        // wei <-> gas exchange ratio


### PR DESCRIPTION
web3 contract call has no option to set the from address. The rpc call was using a from of `0x0000000000000000000000000000000000000000`. The spec shows the From field is optional, so this patch leaves the from field out of the call when the value is nil. 

This is more of a compliance feature than a fix. I ran info this problem by using msg.sender in a view function, but fixed that by passing the address explicitly as a parameter.