### PR TITLE
EIP155: sign with chainID

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/gochain/gochain/v3/common"
 	"github.com/gochain/gochain/v3/common/hexutil"
@@ -45,6 +46,7 @@ type Client interface {
 	// Call executes a call without submitting a transaction.
 	Call(ctx context.Context, msg CallMsg) ([]byte, error)
 	Close()
+	SetChainID(*big.Int)
 }
 
 // Dial returns a new client backed by dialing url (supported schemes "http", "https", "ws" and "wss").
@@ -62,7 +64,8 @@ func NewClient(r *rpc.Client) Client {
 }
 
 type client struct {
-	r *rpc.Client
+	r       *rpc.Client
+	chainID atomic.Value
 }
 
 func (c *client) Close() {
@@ -156,10 +159,21 @@ func (c *client) GetNetworkID(ctx context.Context) (*big.Int, error) {
 	return version, nil
 }
 
+func (c *client) SetChainID(chainID *big.Int) {
+	c.chainID.Store(chainID)
+}
+
 func (c *client) GetChainID(ctx context.Context) (*big.Int, error) {
+	if l := c.chainID.Load(); l != nil {
+		if i := l.(*big.Int); i != nil {
+			return i, nil
+		}
+	}
 	var result hexutil.Big
 	err := c.r.CallContext(ctx, &result, "eth_chainId")
-	return (*big.Int)(&result), err
+	i := (*big.Int)(&result)
+	c.SetChainID(i)
+	return i, err
 }
 
 func (c *client) GetTransactionReceipt(ctx context.Context, hash common.Hash) (*Receipt, error) {

--- a/client.go
+++ b/client.go
@@ -256,7 +256,7 @@ func toBlockNumArg(number *big.Int) string {
 
 func toCallArg(msg CallMsg) interface{} {
 	arg := map[string]interface{}{
-		"to":   msg.To,
+		"to": msg.To,
 	}
 	if msg.From != nil {
 		arg["from"] = msg.From

--- a/cmd/web3/contracts.go
+++ b/cmd/web3/contracts.go
@@ -51,13 +51,8 @@ func GetContractConst(ctx context.Context, rpcURL, contractAddress, contractFile
 	return res, nil
 }
 
-func callContract(ctx context.Context, rpcURL string, chainID *big.Int, privateKey, contractAddress, contractFile, functionName string,
+func callContract(ctx context.Context, client web3.Client, privateKey, contractAddress, contractFile, functionName string,
 	amount *big.Int, gasPrice *big.Int, gasLimit uint64, waitForReceipt, toString bool, parameters ...interface{}) {
-	client, err := web3.Dial(rpcURL)
-	if err != nil {
-		fatalExit(fmt.Errorf("Failed to connect to %q: %v", rpcURL, err))
-	}
-	defer client.Close()
 	myabi, err := web3.GetABI(contractFile)
 	if err != nil {
 		fatalExit(err)
@@ -98,7 +93,7 @@ func callContract(ctx context.Context, rpcURL string, chainID *big.Int, privateK
 		}
 		return
 	}
-	tx, err := web3.CallTransactFunction(ctx, client, chainID, *myabi, contractAddress, privateKey, functionName, amount, gasPrice, gasLimit, parameters...)
+	tx, err := web3.CallTransactFunction(ctx, client, *myabi, contractAddress, privateKey, functionName, amount, gasPrice, gasLimit, parameters...)
 	if err != nil {
 		fatalExit(fmt.Errorf("Error calling contract: %v", err))
 	}

--- a/cmd/web3/contracts.go
+++ b/cmd/web3/contracts.go
@@ -51,7 +51,7 @@ func GetContractConst(ctx context.Context, rpcURL, contractAddress, contractFile
 	return res, nil
 }
 
-func callContract(ctx context.Context, rpcURL, privateKey, contractAddress, contractFile, functionName string,
+func callContract(ctx context.Context, rpcURL string, chainID *big.Int, privateKey, contractAddress, contractFile, functionName string,
 	amount *big.Int, gasPrice *big.Int, gasLimit uint64, waitForReceipt, toString bool, parameters ...interface{}) {
 	client, err := web3.Dial(rpcURL)
 	if err != nil {
@@ -98,7 +98,7 @@ func callContract(ctx context.Context, rpcURL, privateKey, contractAddress, cont
 		}
 		return
 	}
-	tx, err := web3.CallTransactFunction(ctx, client, *myabi, contractAddress, privateKey, functionName, amount, gasPrice, gasLimit, parameters...)
+	tx, err := web3.CallTransactFunction(ctx, client, chainID, *myabi, contractAddress, privateKey, functionName, amount, gasPrice, gasLimit, parameters...)
 	if err != nil {
 		fatalExit(fmt.Errorf("Error calling contract: %v", err))
 	}

--- a/cmd/web3/did.go
+++ b/cmd/web3/did.go
@@ -85,6 +85,7 @@ func CreateDID(ctx context.Context, rpcURL string, chainID *big.Int, privateKey,
 	if err != nil {
 		log.Fatalf("Failed to connect to %q: %v", rpcURL, err)
 	}
+	client.SetChainID(chainID)
 	defer client.Close()
 
 	myabi, err := abi.JSON(strings.NewReader(assets.DIDRegistryABI))
@@ -95,7 +96,7 @@ func CreateDID(ctx context.Context, rpcURL string, chainID *big.Int, privateKey,
 	var idBytes32 [32]byte
 	copy(idBytes32[:], d.ID)
 
-	tx, err := web3.CallTransactFunction(ctx, client, chainID, myabi, registryAddress, privateKey, "register", &big.Int{}, nil, 70000, idBytes32, hash)
+	tx, err := web3.CallTransactFunction(ctx, client, myabi, registryAddress, privateKey, "register", &big.Int{}, nil, 70000, idBytes32, hash)
 	if err != nil {
 		log.Fatalf("Cannot register DID identifier: %v", err)
 	}

--- a/cmd/web3/did.go
+++ b/cmd/web3/did.go
@@ -28,7 +28,7 @@ import (
 // MaxDIDLength is the maximum size of the idstring of the GoChain DID.
 const MaxDIDLength = 32
 
-func CreateDID(ctx context.Context, rpcURL, privateKey, id, registryAddress string) {
+func CreateDID(ctx context.Context, rpcURL string, chainID *big.Int, privateKey, id, registryAddress string) {
 	if registryAddress == "" {
 		log.Fatalf("Registry contract address required")
 	} else if id == "" {
@@ -95,7 +95,7 @@ func CreateDID(ctx context.Context, rpcURL, privateKey, id, registryAddress stri
 	var idBytes32 [32]byte
 	copy(idBytes32[:], d.ID)
 
-	tx, err := web3.CallTransactFunction(ctx, client, myabi, registryAddress, privateKey, "register", &big.Int{}, nil, 70000, idBytes32, hash)
+	tx, err := web3.CallTransactFunction(ctx, client, chainID, myabi, registryAddress, privateKey, "register", &big.Int{}, nil, 70000, idBytes32, hash)
 	if err != nil {
 		log.Fatalf("Cannot register DID identifier: %v", err)
 	}

--- a/cmd/web3/main.go
+++ b/cmd/web3/main.go
@@ -501,19 +501,15 @@ func main() {
 						cli.Uint64Flag{
 							Name:  "gas-limit",
 							Value: 70000,
-							
 						},
 
-                                		cli.StringFlag{
-                                       		 	Name:  "gas-price",
-                                        		Usage: "Gas price to use, if left blank, will use suggested gas price.",
-                                		},
-                                		cli.StringFlag{
-                                        	Name:  "gas-price-gwei",
-                                        	Usage: "Gas price to use in GWEI, if left blank, will use suggested gas price.",
-	
-							
-							
+						cli.StringFlag{
+							Name:  "gas-price",
+							Usage: "Gas price to use, if left blank, will use suggested gas price.",
+						},
+						cli.StringFlag{
+							Name:  "gas-price-gwei",
+							Usage: "Gas price to use in GWEI, if left blank, will use suggested gas price.",
 						},
 					},
 				},

--- a/networks.go
+++ b/networks.go
@@ -1,5 +1,7 @@
 package web3
 
+import "math/big"
+
 const (
 	testnetExplorerURL = "https://testnet-explorer.gochain.io/api"
 	mainnetExplorerURL = "https://explorer.gochain.io/api"
@@ -11,12 +13,14 @@ var Networks = map[string]Network{
 	"testnet": {
 		Name:        "testnet",
 		URL:         testnetURL,
+		ChainID:     big.NewInt(31337),
 		Unit:        "GO",
 		ExplorerURL: testnetExplorerURL,
 	},
 	"gochain": {
 		Name:        "gochain",
 		URL:         mainnetURL,
+		ChainID:     big.NewInt(60),
 		Unit:        "GO",
 		ExplorerURL: mainnetExplorerURL,
 	},
@@ -30,13 +34,15 @@ var Networks = map[string]Network{
 		URL:  "https://mainnet.infura.io/v3/bc5b0e5cfd9b4385befb69a68a9400c3",
 		// URL: "https://cloudflare-eth.com", // these don't worry very well, constant problems
 		// URL: "https://main-rpc.linkpool.io",
+		ChainID:     big.NewInt(1),
 		Unit:        "ETH",
 		ExplorerURL: "https://etherscan.io",
 	},
 	"ropsten": {
-		Name: "ropsten",
-		URL:  "https://ropsten-rpc.linkpool.io",
-		Unit: "ETH",
+		Name:    "ropsten",
+		URL:     "https://ropsten-rpc.linkpool.io",
+		ChainID: big.NewInt(3),
+		Unit:    "ETH",
 	},
 }
 
@@ -45,4 +51,5 @@ type Network struct {
 	URL         string
 	ExplorerURL string
 	Unit        string
+	ChainID     *big.Int
 }

--- a/types.go
+++ b/types.go
@@ -10,7 +10,7 @@ import (
 )
 
 type CallMsg struct {
-	From     *common.Address  // the sender of the 'transaction'
+	From     *common.Address // the sender of the 'transaction'
 	To       *common.Address // the destination contract (nil for contract creation)
 	Gas      uint64          // if 0, the call executes with near-infinite gas
 	GasPrice *big.Int        // wei <-> gas exchange ratio

--- a/web3.go
+++ b/web3.go
@@ -110,7 +110,7 @@ func CallConstantFunction(ctx context.Context, client Client, myabi abi.ABI, add
 }
 
 // CallTransactFunction submits a transaction to execute a smart contract function call.
-func CallTransactFunction(ctx context.Context, client Client, chainID *big.Int, myabi abi.ABI, address, privateKeyHex, functionName string,
+func CallTransactFunction(ctx context.Context, client Client, myabi abi.ABI, address, privateKeyHex, functionName string,
 	amount *big.Int, gasPrice *big.Int, gasLimit uint64, params ...interface{}) (*Transaction, error) {
 	if address == "" {
 		return nil, errors.New("no contract address specified")
@@ -137,12 +137,11 @@ func CallTransactFunction(ctx context.Context, client Client, chainID *big.Int, 
 			return nil, fmt.Errorf("cannot get gas price: %v", err)
 		}
 	}
-	if chainID == nil {
-		chainID, err = client.GetChainID(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't get chain ID: %v", err)
-		}
+	chainID, err := client.GetChainID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get chain ID: %v", err)
 	}
+
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
@@ -192,7 +191,7 @@ func downloadFile(url string) ([]byte, error) {
 }
 
 // DeployBin will deploy a bin file to the network
-func DeployBin(ctx context.Context, client Client, chainID *big.Int, privateKeyHex, binFilename, abiFilename string,
+func DeployBin(ctx context.Context, client Client, privateKeyHex, binFilename, abiFilename string,
 	gasPrice *big.Int, gasLimit uint64, constructorArgs ...interface{}) (*Transaction, error) {
 	var bin []byte
 	var err error
@@ -214,7 +213,6 @@ func DeployBin(ctx context.Context, client Client, chainID *big.Int, privateKeyH
 			if err != nil {
 				return nil, fmt.Errorf("Cannot download the abi file %q: %v", abiFilename, err)
 			}
-
 		} else {
 			abi, err = ioutil.ReadFile(abiFilename)
 			if err != nil {
@@ -223,13 +221,12 @@ func DeployBin(ctx context.Context, client Client, chainID *big.Int, privateKeyH
 		}
 	}
 
-	return DeployContract(ctx, client, chainID, privateKeyHex, string(bin), string(abi), gasPrice, gasLimit, constructorArgs...)
-
+	return DeployContract(ctx, client, privateKeyHex, string(bin), string(abi), gasPrice, gasLimit, constructorArgs...)
 }
 
 // DeployContract submits a contract creation transaction.
 // abiJSON is only required when including params for the constructor.
-func DeployContract(ctx context.Context, client Client, chainID *big.Int, privateKeyHex string, binHex, abiJSON string, gasPrice *big.Int, gasLimit uint64, constructorArgs ...interface{}) (*Transaction, error) {
+func DeployContract(ctx context.Context, client Client, privateKeyHex string, binHex, abiJSON string, gasPrice *big.Int, gasLimit uint64, constructorArgs ...interface{}) (*Transaction, error) {
 	if len(privateKeyHex) > 2 && privateKeyHex[:2] == "0x" {
 		privateKeyHex = privateKeyHex[2:]
 	}
@@ -244,11 +241,9 @@ func DeployContract(ctx context.Context, client Client, chainID *big.Int, privat
 			return nil, fmt.Errorf("cannot get gas price: %v", err)
 		}
 	}
-	if chainID == nil {
-		chainID, err = client.GetChainID(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't get chain ID: %v", err)
-		}
+	chainID, err := client.GetChainID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get chain ID: %v", err)
 	}
 
 	publicKey := privateKey.Public()
@@ -300,7 +295,7 @@ func DeployContract(ctx context.Context, client Client, chainID *big.Int, privat
 }
 
 // Send performs a regular native coin transaction (not a contract)
-func Send(ctx context.Context, client Client, chainID *big.Int, privateKeyHex string, address common.Address, amount *big.Int, gasPrice *big.Int, gasLimit uint64) (*Transaction, error) {
+func Send(ctx context.Context, client Client, privateKeyHex string, address common.Address, amount *big.Int, gasPrice *big.Int, gasLimit uint64) (*Transaction, error) {
 	if len(privateKeyHex) > 2 && privateKeyHex[:2] == "0x" {
 		privateKeyHex = privateKeyHex[2:]
 	}
@@ -314,12 +309,11 @@ func Send(ctx context.Context, client Client, chainID *big.Int, privateKeyHex st
 			return nil, fmt.Errorf("cannot get gas price: %v", err)
 		}
 	}
-	if chainID == nil {
-		chainID, err = client.GetChainID(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't get chain ID: %v", err)
-		}
+	chainID, err := client.GetChainID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get chain ID: %v", err)
 	}
+
 	if gasLimit == 0 {
 		gasLimit = 21000
 	}


### PR DESCRIPTION
This change adds `Network.ChainID` for known networks and logic for fetching it for unknown RPC URLs, in order to use with signing transactions more securely with EIP155.

Fixes #201