### PR TITLE
Add git to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cd $D && go build -o web3-alpine ./cmd/web3 && cp web3-alpine /tmp/
 
 # final stage
 FROM alpine
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates git
 WORKDIR /app
 COPY --from=build-env /tmp/web3-alpine /app/web3
 ENTRYPOINT ["/app/web3"]


### PR DESCRIPTION
This is a fix for #291 and it installs git binary to the Docker image in order to be able to use web3 image for [Generating Common Contracts](https://github.com/gochain/web3#generating-common-contracts).

A single drawback is that size will slightly increase
```shell
docker images -a | grep web3
web3-git       latest   0a9e9c666a5f   44 seconds ago   58MB
gochain/web3   latest   88dded04d5cb   5 months ago     42MB
```