### PR TITLE
Fix cli error on empty input array #294

### DIFF
--- a/web3.go
+++ b/web3.go
@@ -467,6 +467,9 @@ func ConvertArgument(abiType abi.Type, param interface{}) (interface{}, error) {
 		s = strings.TrimPrefix(s, "[")
 		s = strings.TrimSuffix(s, "]")
 		inputArray := strings.Split(s, ",")
+		if s == "" {
+			inputArray = nil
+		}
 		switch abiType.Elem.T {
 
 		case abi.AddressTy:


### PR DESCRIPTION
strings.Split on empty string results in a slice with one empty string ([""]) instead of 0-length ([]).